### PR TITLE
Network Hashrate, standard data directories, changed binary names.

### DIFF
--- a/src/makefile.linux-mingw
+++ b/src/makefile.linux-mingw
@@ -93,7 +93,7 @@ OBJS= \
     obj/leveldb.o \
     obj/txdb.o
 
-all: bitcoind.exe
+all: DogeBlackCoin.exe
 
 DEFS += -I"$(CURDIR)/leveldb/include"
 DEFS += -I"$(CURDIR)/leveldb/helpers"
@@ -108,7 +108,7 @@ DEFS += -DHAVE_BUILD_INFO
 obj/%.o: %.cpp $(HEADERS)
 	$(CXX) -c $(xCXXFLAGS) -o $@ $<
 
-bitcoind.exe: $(OBJS:obj/%=obj/%)
+DogeBlack.exe: $(OBJS:obj/%=obj/%)
 	$(CXX) $(xCXXFLAGS) $(xLDFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
 
 TESTOBJS := $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp))
@@ -122,7 +122,7 @@ test_bitcoin.exe: $(TESTOBJS) $(filter-out obj/init.o,$(OBJS:obj/%=obj/%))
 
 clean:
 	-rm -f obj/*.o
-	-rm -f bitcoind.exe
+	-rm -f DogeBlack.exe
 	-rm -f obj-test/*.o
 	-rm -f test_bitcoin.exe
 	-rm -f obj/build.h

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -102,7 +102,7 @@ OBJS= \
     obj/txdb.o
 
 
-all: bitcoind.exe
+all: DogeBlack.exe
 
 test check: test_bitcoin.exe FORCE
 	test_bitcoin.exe
@@ -119,7 +119,7 @@ leveldb/libleveldb.a:
 obj/%.o: %.cpp $(HEADERS)
 	$(CXX) -c $(CFLAGS) -o $@ $<
 
-bitcoind.exe: $(OBJS:obj/%=obj/%)
+DogeBlack.exe: $(OBJS:obj/%=obj/%)
 	$(CXX) $(CFLAGS) $(LDFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
 
 TESTOBJS := $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp))
@@ -131,7 +131,7 @@ test_bitcoin.exe: $(TESTOBJS) $(filter-out obj/init.o,$(OBJS:obj/%=obj/%))
 	$(CXX) $(CFLAGS) $(LDFLAGS) -o $@ $(LIBPATHS) $^ -lboost_unit_test_framework$(BOOST_SUFFIX) $(LIBS)
 
 clean:
-	rm -f bitcoind.exe test_bitcoin.exe
+	rm -f DogeBlack.exe test_bitcoin.exe
 	rm -f obj/*
 	rm -f obj-test/*
 	cd leveldb && $(MAKE) TARGET_OS=NATIVE_WINDOWS clean && cd ..

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -27,7 +27,7 @@ LIBS= -dead_strip
 TESTDEFS = -DTEST_DATA_DIR=$(abspath test/data)
 
 ifdef STATIC
-# Build STATIC if you are redistributing the bitcoind binary
+# Build STATIC if you are redistributing the DogeBlack binary
 TESTLIBS += \
  $(DEPSDIR)/lib/libboost_unit_test_framework-mt.a
 LIBS += \
@@ -120,7 +120,7 @@ ifneq (${USE_IPV6}, -)
 	DEFS += -DUSE_IPV6=$(USE_IPV6)
 endif
 
-all: bitcoind
+all: DogeBlack
 
 test check: test_bitcoin FORCE
 	./test_bitcoin
@@ -150,7 +150,7 @@ obj/%.o: %.cpp
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
 	  rm -f $(@:%.o=%.d)
 
-bitcoind: $(OBJS:obj/%=obj/%)
+DogeBlack: $(OBJS:obj/%=obj/%)
 	$(CXX) $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS)
 
 TESTOBJS := $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp))
@@ -166,7 +166,7 @@ test_bitcoin: $(TESTOBJS) $(filter-out obj/init.o,$(OBJS:obj/%=obj/%))
 	$(CXX) $(CFLAGS) -o $@ $(LIBPATHS) $^ $(LIBS) $(TESTLIBS)
 
 clean:
-	-rm -f bitcoind test_bitcoin
+	-rm -f DogeBlack test_bitcoin
 	-rm -f obj/*.o
 	-rm -f obj-test/*.o
 	-rm -f obj/*.P

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -144,7 +144,7 @@ OBJS= \
     obj/txdb.o
 
 
-all: bitcoind
+all: DogeBlackCoind
 
 test check: test_bitcoin FORCE
 	./test_bitcoin
@@ -175,7 +175,7 @@ obj/%.o: %.cpp
 	      -e '/^$$/ d' -e 's/$$/ :/' < $(@:%.o=%.d) >> $(@:%.o=%.P); \
 	  rm -f $(@:%.o=%.d)
 
-bitcoind: $(OBJS:obj/%=obj/%)
+DogeBlackCoind: $(OBJS:obj/%=obj/%)
 	$(LINK) $(xCXXFLAGS) -o $@ $^ $(xLDFLAGS) $(LIBS)
 
 TESTOBJS := $(patsubst test/%.cpp,obj-test/%.o,$(wildcard test/*.cpp))

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -60,6 +60,54 @@ Value gethashespersec(const Array& params, bool fHelp)
     return (boost::int64_t)dHashesPerSec;
 }
 
+Value GetNetworkHashPS(int lookup, int height) {
+     CBlockIndex *pb = pindexBest;
+ 
+     if (height >= 0 && height < nBestHeight)
+         pb = FindBlockByHeight(height);
+ 
+     if (pb == NULL || !pb->nHeight)
+         return 0;
+ 
+     // If lookup is -1, then use blocks since last difficulty change.
+     if (lookup <= 0)
+         lookup = pb->nHeight % 2016 + 1;
+ 
+     // If lookup is larger than chain, then set it to chain length.
+     if (lookup > pb->nHeight)
+         lookup = pb->nHeight;
+ 
+     CBlockIndex *pb0 = pb;
+     int64 minTime = pb0->GetBlockTime();
+     int64 maxTime = minTime;
+     for (int i = 0; i < lookup; i++) {
+         pb0 = pb0->pprev;
+         int64 time = pb0->GetBlockTime();
+         minTime = std::min(time, minTime);
+         maxTime = std::max(time, maxTime);
+     }
+ 
+     // In case there's a situation where minTime == maxTime, we don't want a divide by zero exception.
+     if (minTime == maxTime)
+         return 0;
+ 
+     uint256 workDiff = pb->nChainWork - pb0->nChainWork;
+     int64 timeDiff = maxTime - minTime;
+ 
+     return (boost::int64_t)(workDiff.getdouble() / timeDiff);
+}
+
+ Value getnetworkhashps(const Array& params, bool fHelp)
+ {
+     if (fHelp || params.size() > 2)
+         throw runtime_error(
+             "getnetworkhashps [blocks] [height]\n"
+             "Returns the estimated network hashes per second based on the last 120 blocks.\n"
+             "Pass in [blocks] to override # of blocks, -1 specifies since last difficulty change.\n"
+             "Pass in [height] to estimate the network speed at the time when a certain block was found.");
+ 
+     return GetNetworkHashPS(params.size() > 0 ? params[0].get_int() : 120, params.size() > 1 ? params[1].get_int() : -1);
+ }
 
 Value getmininginfo(const Array& params, bool fHelp)
 {
@@ -76,6 +124,7 @@ Value getmininginfo(const Array& params, bool fHelp)
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
     obj.push_back(Pair("generate",      GetBoolArg("-gen")));
     obj.push_back(Pair("genproclimit",  (int)GetArg("-genproclimit", -1)));
+    obj.push_back(Pair("networkhashps",   getnetworkhashps(params, false)));
     obj.push_back(Pair("hashespersec",  gethashespersec(params, false)));
     obj.push_back(Pair("pooledtx",      (uint64_t)mempool.size()));
     obj.push_back(Pair("testnet",       fTestNet));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -994,7 +994,7 @@ static std::string FormatException(std::exception* pex, const char* pszThread)
     char pszModule[MAX_PATH] = "";
     GetModuleFileNameA(NULL, pszModule, sizeof(pszModule));
 #else
-    const char* pszModule = "bitcoin";
+    const char* pszModule = "DogeBlackCoin";
 #endif
     if (pex)
         return strprintf(

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1068,7 +1068,7 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
 
 boost::filesystem::path GetConfigFile()
 {
-    boost::filesystem::path pathConfigFile(GetArg("-conf", "coin.conf"));
+    boost::filesystem::path pathConfigFile(GetArg("-conf", "DogeBlackCoin.conf"));
     if (!pathConfigFile.is_complete()) pathConfigFile = GetDataDir(false) / pathConfigFile;
     return pathConfigFile;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1030,7 +1030,9 @@ void PrintExceptionContinue(std::exception* pex, const char* pszThread)
 boost::filesystem::path GetDefaultDataDir()
 {
     namespace fs = boost::filesystem;
-    return fs::path(".DogeBlackCoin");
+    fs::path pathRet;
+    return pathRet / ".DogeBlackCoin";
+
 }
 
 const boost::filesystem::path &GetDataDir(bool fNetSpecific)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1030,7 +1030,7 @@ void PrintExceptionContinue(std::exception* pex, const char* pszThread)
 boost::filesystem::path GetDefaultDataDir()
 {
     namespace fs = boost::filesystem;
-    return fs::path(".");
+    return fs::path(".DogeBlackCoin");
 }
 
 const boost::filesystem::path &GetDataDir(bool fNetSpecific)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1062,7 +1062,7 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
     if (fNetSpecific && GetBoolArg("-testnet", false))
         path /= "testnet3";
 
-    fs::create_directories(path);
+    fs::create_directory(path);
 
     fCachedPath[fNetSpecific] = true;
     return path;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1030,8 +1030,26 @@ void PrintExceptionContinue(std::exception* pex, const char* pszThread)
 boost::filesystem::path GetDefaultDataDir()
 {
     namespace fs = boost::filesystem;
+#ifdef WIN32
+    // Windows
+    return GetSpecialFolderPath(CSIDL_APPDATA) / "DogeBlackCoin";
+#else
     fs::path pathRet;
+    char* pszHome = getenv("HOME");
+    if (pszHome == NULL || strlen(pszHome) == 0)
+        pathRet = fs::path("/");
+    else
+        pathRet = fs::path(pszHome);
+#ifdef MAC_OSX
+    // Mac
+    pathRet /= "Library/Application Support";
+    fs::create_directory(pathRet);
+    return pathRet / "DogeBlackCoin";
+#else
+    // Unix
     return pathRet / ".DogeBlackCoin";
+#endif
+#endif
 
 }
 


### PR DESCRIPTION
I made a few changes to the source which do not affect the core functionality of the client.  Added a method to properly calculate current network hashrate.  The default data directory is now "DarkBlackCoin" in the standard location used by most coins based on operation system used.  The compiled binary is now named "DogeBlackCoin" and the default config file is named "DogeBlackCoin.conf".  Only linux daemon tested but the other operating systems should work as well.
